### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 A Model Context Protocol (MCP) server that connects Claude to BrianKnows' blockchain knowledge base.
 
+<a href="https://glama.ai/mcp/servers/idfph0fstx">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/idfph0fstx/badge" alt="BrianKnows Server MCP server" />
+</a>
+
 ## What is MCP? 🤔
 
 The Model Context Protocol (MCP) lets AI assistants like Claude Desktop connect to external tools and data sources in a secure way while keeping users in control.


### PR DESCRIPTION
This PR adds a badge for the [BrianKnows MCP Server](https://glama.ai/mcp/servers/idfph0fstx) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/idfph0fstx">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/idfph0fstx/badge" alt="BrianKnows Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.